### PR TITLE
Fix announcements author display

### DIFF
--- a/src/canvas_mcp/sync/announcements.py
+++ b/src/canvas_mcp/sync/announcements.py
@@ -85,12 +85,21 @@ def sync_announcements(sync_service, course_ids: list[int] | None = None) -> int
         for raw_announcement in raw_announcements:
             try:
                 # Prepare data for validation
+                # Get author information from the author dictionary or fallback to user_name
+                author_name = None
+                author_dict = getattr(raw_announcement, "author", None)
+                if author_dict and isinstance(author_dict, dict):
+                    author_name = author_dict.get("display_name")
+
+                if not author_name:
+                    author_name = getattr(raw_announcement, "user_name", None)
+
                 announcement_data = {
                     "id": raw_announcement.id,
                     "course_id": local_course_id,
                     "title": getattr(raw_announcement, "title", ""),
                     "message": getattr(raw_announcement, "message", None),
-                    "author_name": getattr(raw_announcement, "author_name", None),
+                    "author_name": author_name,
                     "posted_at": getattr(raw_announcement, "posted_at", None),
                 }
 


### PR DESCRIPTION
This PR fixes the issue where announcements were not displaying the author information. The problem was in the sync_announcements.py file where we were trying to access the author information using `author_name` attribute, but the Canvas API actually provides this information in two different ways:

1. As an `author` dictionary with a `display_name` key
2. As a `user_name` attribute directly on the announcement object

The fix updates the code to check both locations for the author information, ensuring that the `posted_by` field is correctly populated in the database.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author